### PR TITLE
Automatic USD-ETH rate reading in DPTICO contract

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "lib/medianizer"]
 	path = lib/medianizer
 	url = https://github.com/makerdao/medianizer.git
+[submodule "lib/ds-note"]
+	path = lib/ds-note
+	url = https://github.com/dapphub/ds-note.git

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+### deploy -- command-line interface to deploy DPTICO smart contract
+### Usage: deploy 
+
+### Before using deploy, you should copy the keystore file from your keystore to current directory. See:
+### geth - https://github.com/ethereum/go-ethereum/wiki/Backup-&-restore
+### parity - https://ethereum.stackexchange.com/questions/6471/where-are-my-keys-and-chain-data-located-if-i-am-using-parity
+
+set -ex
+
+## Settings
+PRICE_FEED="0x729D19f657BD0614b4985Cf1D82531c67569197B" #MakerDAO pricefeed address
+DPT_USD_RATE=3.5    #DPT price in terms of US Dollars (you can modify it in the smart ocntract)
+ETH_USD_RATE=259.84 #just a default value. The rate is received from PRICE_FEED.
+
+## Internal settings (do not touch these unless you know what you are doing!!)
+export ETH_KEYSTORE=`pwd`
+export ETH_RPC_PORT=${ETH_RPC_PORT:-"8545"}
+
+test -z $SYMBOL && exit 1
+
+if ! [[ $PRICE_FEED =~ ^0x[0-9a-fA-F]{40}$ ]]
+    then
+        exit 1
+fi
+
+if ! [[ $DPT_USD_RATE =~ ^[0-9.]+$ ]]
+    then
+        exit 1
+fi
+
+if ! [[ $ETH_USD_RATE =~ ^[0-9.]+$ ]]
+    then
+        exit 1
+fi
+
+export SOLC_FLAGS=${SOLC_FLAGS:-"--optimize"}
+export ETH_GAS=${ETH_GAS:-"4000000"}
+export ETH_FROM=$(seth rpc eth_coinbase)
+export NETWORK=$(seth chain)
+
+test -z $NETWORK && exit 1
+
+dapp build
+
+DPT=$(dapp create DPT)
+
+export DPT=$DPT
+echo "DPT DEPLOYED AT: $DPT\n"
+
+test -z $DPT && exit 1
+
+DPTICO=$(dapp create DPTICO "$DPT" "$PRICE_FEED" "$(seth --to-uint256 $(seth --to-wei $DPT_USD_RATE eth))" "$(seth --to-uint256 $(seth --to-wei $ETH_USD_RATE eth))")
+
+export DPTICO=$DPTICO
+echo "DPTICO DEPLOYED AT: $DPTICO\n"

--- a/src/DPTICO.sol
+++ b/src/DPTICO.sol
@@ -16,7 +16,7 @@ contract DPTICOEvents {
     event TokenBought(address owner, address sender, uint dptValue, uint _ethUSDRate, uint _dptUSDRate);
     event FeedValid(bool feedValid);
 }
-contract DPTICO is DSAuth, DSStop, DSMath {
+contract DPTICO is DSAuth, DSStop, DSMath, DPTICOEvents {
     uint public rate = 1 ether;         //set exchange rate of 1 DPT/ETH
     uint public _dptUSDRate;            //usd price of 1 DPT token. 18 digit precision
     uint public _ethUSDRate;            //price of ETH in USD. 18 digit precision

--- a/src/DPTICO.sol
+++ b/src/DPTICO.sol
@@ -4,6 +4,7 @@ import "ds-math/math.sol";
 import "ds-auth/auth.sol";
 import "ds-token/token.sol";
 import "ds-stop/stop.sol";
+import "ds-note/note.sol";
 
 contract MedianizerLike {
     function peek() external view returns (bytes32, bool); 
@@ -13,31 +14,34 @@ contract MedianizerLike {
  * @dev DPTICO contract.
  */
 contract DPTICOEvents {
-    event LogBuyToken(address owner, address sender, uint dptValue, uint _ethUSDRate, uint _dptUSDRate);
+    event LogBuyToken(
+        address owner, 
+        address sender, 
+        uint ethValue,
+        uint dptValue, 
+        uint ethUsdRate, 
+        uint dptUsdRate
+    );
     event LogFeedValid(bool feedValid);
-    event LogDptUsdRate(uint _dptUSDRate);
-    event LogEthUsdRate(uint _ethUSDRate);
-    event LogPriceFeed(address _priceFeed);
-    event LogManualUSDRate(bool _manualUSDRate);
 }
 
 contract DPTICO is DSAuth, DSStop, DSMath, DPTICOEvents {
-    uint public rate = 1 ether;         //set exchange rate of 1 DPT/ETH
-    uint public _dptUSDRate;            //usd price of 1 DPT token. 18 digit precision
-    uint public _ethUSDRate;            //price of ETH in USD. 18 digit precision
-    MedianizerLike public _priceFeed;   //address of the Makerdao price feed
-    bool public feedValid;              //if true feed has valid USD/ETH rate
-    DSToken public _dpt;                //DPT token contract
-    bool public _manualUSDRate;         //if true enables token buy even if _priceFeed does not provide valid data
+    uint public rate = 1 ether;        //set exchange rate of 1 DPT/ETH
+    uint public dptUsdRate;            //usd price of 1 DPT token. 18 digit precision
+    uint public ethUsdRate;            //price of ETH in USD. 18 digit precision
+    MedianizerLike public priceFeed;   //address of the Makerdao price feed
+    bool public feedValid;             //if true feed has valid USD/ETH rate
+    ERC20 public dpt;                  //DPT token contract
+    bool public manualUsdRate = true;  //if true enables token buy even if priceFeed does not provide valid data
 
     /**
-    * @dev Constructor that gives msg.sender all of existing tokens.
+    * @dev Constructor 
     */
-    constructor(address dpt, address priceFeed, uint dptUSDRate, uint etherUsdRate) public {
-         _dpt = DSToken(dpt);
-         _priceFeed = MedianizerLike(priceFeed);
-         _dptUSDRate = dptUSDRate;
-         _ethUSDRate = etherUsdRate;
+    constructor(address dpt_, address priceFeed_, uint dptUsdRate_, uint ethUsdRate_) public {
+         dpt = ERC20(dpt_);
+         priceFeed = MedianizerLike(priceFeed_);
+         dptUsdRate = dptUsdRate_;
+         ethUsdRate = ethUsdRate_;
     }
 
     /**
@@ -53,63 +57,59 @@ contract DPTICO is DSAuth, DSStop, DSMath, DPTICOEvents {
     function buyTokens() public payable stoppable {
         uint tokens;
         bool feedValidSave = feedValid;
-        bytes32 ethUSDRateB;
+        bytes32 ethUsdRateB;
         require(msg.value != 0);
         
-        (ethUSDRateB, feedValid) = _priceFeed.peek();           //receive ETH/USD price from external feed
+        (ethUsdRateB, feedValid) = priceFeed.peek();                       //receive ETH/USD price from external feed
         if(feedValidSave != feedValid) { emit LogFeedValid(feedValid); }   //emit LogFeedValid event if validity of feed changes
-        if(feedValid) {                                                 //if feed is valid, load ETH/USD rate from it
-            _ethUSDRate = uint(ethUSDRateB); 
+        if(feedValid) {                                                     
+            ethUsdRate = uint(ethUsdRateB);                                //if feed is valid, load ETH/USD rate from it
         }else{
-            require(_manualUSDRate);
+            require(manualUsdRate);                                        //if feed invalid revert if manualUSDRate_ is NOT allowed
         }
-        tokens = wdiv(wmul(_ethUSDRate, msg.value), _dptUSDRate);
+        tokens = wdiv(wmul(ethUsdRate, msg.value), dptUsdRate);
         address(owner).transfer(msg.value);
-        _dpt.transferFrom(owner, msg.sender, tokens);
-        emit LogBuyToken(owner, msg.sender, tokens, _ethUSDRate, _dptUSDRate);
+        dpt.transferFrom(owner, msg.sender, tokens);
+        emit LogBuyToken(owner, msg.sender, msg.value, tokens, ethUsdRate, dptUsdRate);
     }
 
     /**
     * @dev Set exchange rate DPT/USD value. 
     */
-    function setDPTRate(uint dptUSDRate) public auth {
-        require(dptUSDRate > 0);
-        _dptUSDRate = dptUSDRate;
-        emit LogDptUsdRate(_dptUSDRate);
+    function setDptRate(uint dptUsdRate_) public auth note {
+        require(dptUsdRate_ > 0);
+        dptUsdRate = dptUsdRate_;
     }
 
     /**
     * @dev Set exchange rate DPT/ETH value manually.
     * 
-    * This function should only be used if the _priceFeed does not return
+    * This function should only be used if the priceFeed does not return
     * valid price data.
     *
     */
-    function setETHRate(uint ethUSDRate) public auth {
-        require(_manualUSDRate);
-        _ethUSDRate = ethUSDRate;
-        emit LogEthUsdRate(_ethUSDRate);
+    function setEthRate(uint ethUsdRate_) public auth note {
+        require(manualUsdRate);
+        ethUsdRate = ethUsdRate_;
     }
 
     /**
     * @dev Set the price feed
     */
-    function setPriceFeed(address priceFeed) public auth {
-        require(priceFeed != 0x0);
-        _priceFeed = MedianizerLike(priceFeed);
-        emit LogPriceFeed(address(_priceFeed));
+    function setPriceFeed(address priceFeed_) public auth note {
+        require(priceFeed_ != 0x0);
+        priceFeed = MedianizerLike(priceFeed_);
     }
 
     /**
     * @dev Set manual feed update
     * 
-    * If _manualUSDRate is true, then buyTokens() will calculate the DPT amount based on latest valid _ethUSDRate, 
-    * so _ethUSDRate must be updated by admins if _priceFeed fails to provide valid price data.
+    * If `manualUsdRate` is true, then `buyTokens()` will calculate the DPT amount based on latest valid `ethUsdRate`, 
+    * so `ethUsdRate` must be updated by admins if priceFeed fails to provide valid price data.
     * 
-    * If _manualUSDRate is false, then buyTokens() will simply revert if _priceFeed does not provide valid price data.
+    * If manualUsdRate is false, then buyTokens() will simply revert if priceFeed does not provide valid price data.
     */
-    function setManualUSDRate(bool manualUSDRate) public auth {
-        _manualUSDRate = manualUSDRate;
-        emit LogManualUSDRate(_manualUSDRate);
+    function setManualUsdRate(bool manualUsdRate_) public auth note {
+        manualUsdRate = manualUsdRate_;
     }
 }

--- a/src/DPTICO.sol
+++ b/src/DPTICO.sol
@@ -5,20 +5,33 @@ import "ds-auth/auth.sol";
 import "ds-token/token.sol";
 import "ds-stop/stop.sol";
 
+contract MedianizerLike {
+    function peek() external view returns (bytes32, bool); 
+}
 /**
  * @title DPT
  * @dev DPTICO contract.
  */
+contract DPTICOEvents {
+    event TokenBought(address owner, address sender, uint dptValue, uint _ethUSDRate, uint _dptUSDRate);
+    event FeedValid(bool feedValid);
+}
 contract DPTICO is DSAuth, DSStop, DSMath {
-    uint256 public rate = 1 ether;  //set exchange rate of 1 DPT/ETH
-
-    DSToken _dpt;                   //DPT token contract
+    uint public rate = 1 ether;         //set exchange rate of 1 DPT/ETH
+    uint public _dptUSDRate;            //usd price of 1 DPT token. 18 digit precision
+    uint public _ethUSDRate;            //price of ETH in USD. 18 digit precision
+    MedianizerLike public _priceFeed;   //address of the Makerdao price feed
+    bool public feedValid;              //if true feed has valid USD/ETH rate
+    DSToken public _dpt;                //DPT token contract
 
     /**
     * @dev Constructor that gives msg.sender all of existing tokens.
     */
-    constructor(DSToken dpt) public {
+    constructor(DSToken dpt, MedianizerLike priceFeed, uint usdPrice, uint etherUsdRate) public {
          _dpt = dpt;
+         _priceFeed = priceFeed;
+         _dptUSDRate = usdPrice;
+         _ethUSDRate = etherUsdRate;
     }
 
     /**
@@ -33,16 +46,53 @@ contract DPTICO is DSAuth, DSStop, DSMath {
     */
     function buyTokens() public payable stoppable {
         uint tokens;
+        bool feedValidSave = feedValid;
         require(msg.value != 0);
-        tokens = wmul(rate, msg.value);
+        (bytes32 ethUSDRateB, feedValid) = _priceFeed.peek();
+        if(feedValidSave != feedValid) { emit FeedValid(feedValid); }
+        require(feedValid || _manualUSDRate);
+        _ethUSDRate = uint(ethUSDRateB);
+        tokens = wdiv(wmul(_ethUSDRate, msg.value), _dptUSDRate);
         address(owner).transfer(msg.value);
         _dpt.transferFrom(owner, msg.sender, tokens);
+        emit TokenBought(owner, msg.sender, tokens, _ethUSDRate, _dptUSDRate);
     }
 
     /**
-    * @dev Set exchange rate DPT/ETH value. 
+    * @dev Set exchange rate DPT/USD value. 
     */
-    function setRate(uint256 newRate) public auth {
-        rate = newRate;
+    function setUSDRate(uint256 dptUSDRate) public auth {
+        _dptUSDRate = dptUSDRate;
+    }
+
+    /**
+    * @dev Set exchange rate DPT/ETH value manually.
+    * 
+    * This function should only be used if the _priceFeed does not return
+    * valid price data.
+    *
+    */
+    function setETHRate(uint256 dptUSDRate) public auth {
+        require(_manualUSDRate);
+        _ethUSDRate = dptUSDRate;
+    }
+
+    /**
+    * @dev Set the price feed
+    */
+    function setPriceFeed(address priceFeed) public auth {
+        _priceFeed = priceFeed;
+    }
+
+    /**
+    * @dev Set manual feed update
+    * 
+    * If _manualUSDRate is true, then buyTokens() will calculate the DPT amount based on latest valid _ethUSDRate, 
+    * so _ethUSDRate must be updated by admins if _priceFeed fails to provide valid price data.
+    * 
+    * If _manualUSDRate is false, then buyTokens() will simply revert if _priceFeed does not provide valid price data.
+    */
+    function setManualUSDRate(bool manualUSDRate) public auth {
+        _manualUSDRate = manualUSDRate;
     }
 }

--- a/src/DPTICO.t.sol
+++ b/src/DPTICO.t.sol
@@ -5,6 +5,28 @@ import "ds-math/math.sol";
 import "./DPTICO.sol"; 
 import "./DPT.sol"; 
 
+contract TestMedianizerLike {
+    bytes32 _ethUSDRate;
+    bool _feedValid;
+
+    constructor(uint ethUSDRate, bool feedValid) public {
+        _ethUSDRate = bytes32(ethUSDRate);
+        _feedValid = feedValid;
+    }
+    
+    function setETHUSDRate(uint ethUSDRate) public {
+        _ethUSDRate = bytes32(ethUSDRate);
+    }
+    
+    function setValid(bool feedValid) public {
+        _feedValid = feedValid;
+    }
+
+    function peek() external view returns (bytes32, bool) {
+        return (_ethUSDRate,_feedValid);
+    } 
+}
+
 contract DPTICOTester {
     DPTICO public _ico;
     
@@ -20,17 +42,21 @@ contract DPTICOTester {
     }
 }
 
-contract DPTICOTest is DSTest, DSMath {
+contract DPTICOTest is DSTest, DSMath, DPTICOEvents {
     uint constant DPT_SUPPLY = (10 ** 7) * (10 ** 18);
     DPT dpt;
+    TestMedianizerLike feed;
     DPTICO ico;
     DPTICOTester user;
     uint etherBalance ;
     uint sendEth;
+    uint ethUSDRate = 317.96 ether;
+    uint dptUSDRate = 3.5 ether;
     
     function setUp() public {
         dpt = new DPT();
-        ico = new DPTICO(dpt);
+        feed = new TestMedianizerLike(ethUSDRate, true); 
+        ico = new DPTICO(dpt, feed, dptUSDRate, ethUSDRate);
         user = new DPTICOTester(ico);
         dpt.approve(ico, uint(-1));
         require(dpt.balanceOf(this) == DPT_SUPPLY);
@@ -54,15 +80,7 @@ contract DPTICOTest is DSTest, DSMath {
     function testOthersBuyTenTokens() public {
         sendEth = 10 ether;
         user.doBuyTokens(sendEth);
-        assertEq(dpt.balanceOf(this),DPT_SUPPLY - (sendEth));
-    }
-
-    function testBuyTenTokensSetRate() public {
-        sendEth = 10 ether;
-        uint rate = 2 ether ;
-        ico.setRate(rate);
-        user.doBuyTokens(sendEth);
-        assertEq(dpt.balanceOf(this),DPT_SUPPLY - (mul(rate , sendEth) / (1 ether)));
+        assertEq(dpt.balanceOf(this),DPT_SUPPLY - (wdiv(wmul(ethUSDRate, sendEth), dptUSDRate)));
     }
 
     function testFailBuyTenTokensIfIcoStopped() public {
@@ -91,5 +109,97 @@ contract DPTICOTest is DSTest, DSMath {
         sendEth = 10 ether;
         user.doBuyTokens(sendEth);
         assertEq(etherBalance + sendEth, address(this).balance);
+    }
+
+    function testBuyTokens() public {
+        sendEth = 10 ether;
+        user.doBuyTokens(sendEth);
+        assertEq(dpt.balanceOf(this),DPT_SUPPLY - (wdiv(wmul(ethUSDRate, sendEth), dptUSDRate)));
+    }
+
+    function testBuyTokensSetDptUsdRate() public {
+        sendEth = 10 ether;
+        dptUSDRate = 5 ether ;
+        ico.setDPTRate(dptUSDRate);
+        user.doBuyTokens(sendEth);
+        assertEq(dpt.balanceOf(this),DPT_SUPPLY - (wdiv(wmul(ethUSDRate, sendEth), dptUSDRate)));
+    }
+
+    function testFailBuyTokensSetZeroDptUsdRate() public {
+        ico.setDPTRate(0);
+    }
+
+    function testBuyTokensSetEthUsdRate() public {
+        sendEth = 10 ether;
+        ethUSDRate = 300 ether;
+        feed.setETHUSDRate(ethUSDRate);
+        user.doBuyTokens(sendEth);
+        assertEq(dpt.balanceOf(this),DPT_SUPPLY - (wdiv(wmul(ethUSDRate, sendEth), dptUSDRate)));
+    }
+
+    function testBuyTokensSetEthUsdAndDptUsdRate() public {
+        sendEth = 10 ether;
+        ethUSDRate = 300 ether;
+        dptUSDRate = 5 ether ;
+        ico.setDPTRate(dptUSDRate);
+        feed.setETHUSDRate(ethUSDRate);
+        user.doBuyTokens(sendEth);
+        assertEq(dpt.balanceOf(this),DPT_SUPPLY - (wdiv(wmul(ethUSDRate, sendEth), dptUSDRate)));
+    }
+
+    function testBuyTenTokensSetEthUsdAndDptUsdRateStatic() public {
+        ico.setDPTRate(5 ether);
+        feed.setETHUSDRate(20 ether);
+        user.doBuyTokens(10 ether);
+        assertEq(dpt.balanceOf(user), 40 ether);
+    }
+
+    function testBuyTokenSetManualEthUsdRateUpdate() public {
+        sendEth = 10 ether;
+        ethUSDRate = 300 ether;
+        feed.setValid(false);
+        ico.setManualUSDRate(true);
+        ico.setETHRate(ethUSDRate);
+        user.doBuyTokens(sendEth);
+        assertEq(dpt.balanceOf(this),DPT_SUPPLY - (wdiv(wmul(ethUSDRate, sendEth), dptUSDRate)));
+    }
+
+    function testFailBuyTokenSetManualEthUsdRateUpdateIfManuaUSDRatelIsFalse() public {
+        sendEth = 10 ether;
+        ethUSDRate = 300 ether;
+        ico.setETHRate(ethUSDRate);
+        user.doBuyTokens(sendEth);
+        assertEq(dpt.balanceOf(this),DPT_SUPPLY - (wdiv(wmul(ethUSDRate, sendEth), dptUSDRate)));
+    }
+
+    function testInvalidFeedDoesNotUpdateEthUsdRate() public {
+        sendEth = 134 ether;
+        uint feedEthUSDRate = 1400 ether; //should not equal to `ethUSDRate` if you want a reasonable test
+        ico.setManualUSDRate(true);
+        feed.setValid(false);
+        feed.setETHUSDRate(feedEthUSDRate);
+        user.doBuyTokens(sendEth);
+        assertEq(dpt.balanceOf(user), wdiv(wmul(ethUSDRate, sendEth), dptUSDRate));
+    }
+
+    function testFailInvalidFeedFailsIfManualUpdateIsFalse() public {
+        sendEth = 134 ether;
+        ico.setManualUSDRate(false);
+        feed.setValid(false);
+        user.doBuyTokens(sendEth);
+    }
+
+    function testSetFeed() public {
+        sendEth = 10 ether;
+        ethUSDRate = 2000 ether;
+        TestMedianizerLike feed1 = new TestMedianizerLike(ethUSDRate, true);
+        ico.setPriceFeed(feed1);
+        user.doBuyTokens(sendEth);
+        assertEq(dpt.balanceOf(user), wdiv(wmul(ethUSDRate, sendEth), dptUSDRate));
+    }
+
+    function testFailSetZeroAddressFeed() public {
+        TestMedianizerLike feed1 ;
+        ico.setPriceFeed(feed1);
     }
 }

--- a/src/DPTICO.t.sol
+++ b/src/DPTICO.t.sol
@@ -6,16 +6,16 @@ import "./DPTICO.sol";
 import "./DPT.sol"; 
 
 contract TestMedianizerLike {
-    bytes32 _ethUSDRate;
+    bytes32 _ethUsdRate;
     bool _feedValid;
 
-    constructor(uint ethUSDRate, bool feedValid) public {
-        _ethUSDRate = bytes32(ethUSDRate);
+    constructor(uint ethUsdRate, bool feedValid) public {
+        _ethUsdRate = bytes32(ethUsdRate);
         _feedValid = feedValid;
     }
     
-    function setETHUSDRate(uint ethUSDRate) public {
-        _ethUSDRate = bytes32(ethUSDRate);
+    function setEthUsdRate(uint ethUsdRate) public {
+        _ethUsdRate = bytes32(ethUsdRate);
     }
     
     function setValid(bool feedValid) public {
@@ -23,7 +23,7 @@ contract TestMedianizerLike {
     }
 
     function peek() external view returns (bytes32, bool) {
-        return (_ethUSDRate,_feedValid);
+        return (_ethUsdRate,_feedValid);
     } 
 }
 
@@ -50,13 +50,13 @@ contract DPTICOTest is DSTest, DSMath, DPTICOEvents {
     DPTICOTester user;
     uint etherBalance ;
     uint sendEth;
-    uint ethUSDRate = 317.96 ether;
-    uint dptUSDRate = 3.5 ether;
+    uint ethUsdRate = 317.96 ether;
+    uint dptUsdRate = 3.5 ether;
     
     function setUp() public {
         dpt = new DPT();
-        feed = new TestMedianizerLike(ethUSDRate, true); 
-        ico = new DPTICO(dpt, feed, dptUSDRate, ethUSDRate);
+        feed = new TestMedianizerLike(ethUsdRate, true); 
+        ico = new DPTICO(dpt, feed, dptUsdRate, ethUsdRate);
         user = new DPTICOTester(ico);
         dpt.approve(ico, uint(-1));
         require(dpt.balanceOf(this) == DPT_SUPPLY);
@@ -80,7 +80,7 @@ contract DPTICOTest is DSTest, DSMath, DPTICOEvents {
     function testOthersBuyTenTokens() public {
         sendEth = 10 ether;
         user.doBuyTokens(sendEth);
-        assertEq(dpt.balanceOf(this),DPT_SUPPLY - (wdiv(wmul(ethUSDRate, sendEth), dptUSDRate)));
+        assertEq(dpt.balanceOf(this),DPT_SUPPLY - (wdiv(wmul(ethUsdRate, sendEth), dptUsdRate)));
     }
 
     function testFailBuyTenTokensIfIcoStopped() public {
@@ -114,88 +114,89 @@ contract DPTICOTest is DSTest, DSMath, DPTICOEvents {
     function testBuyTokens() public {
         sendEth = 10 ether;
         user.doBuyTokens(sendEth);
-        assertEq(dpt.balanceOf(this),DPT_SUPPLY - (wdiv(wmul(ethUSDRate, sendEth), dptUSDRate)));
+        assertEq(dpt.balanceOf(this),DPT_SUPPLY - (wdiv(wmul(ethUsdRate, sendEth), dptUsdRate)));
     }
 
     function testBuyTokensSetDptUsdRate() public {
         sendEth = 10 ether;
-        dptUSDRate = 5 ether ;
-        ico.setDPTRate(dptUSDRate);
+        dptUsdRate = 5 ether ;
+        ico.setDptRate(dptUsdRate);
         user.doBuyTokens(sendEth);
-        assertEq(dpt.balanceOf(this),DPT_SUPPLY - (wdiv(wmul(ethUSDRate, sendEth), dptUSDRate)));
+        assertEq(dpt.balanceOf(this),DPT_SUPPLY - (wdiv(wmul(ethUsdRate, sendEth), dptUsdRate)));
     }
 
     function testFailBuyTokensSetZeroDptUsdRate() public {
-        ico.setDPTRate(0);
+        ico.setDptRate(0);
     }
 
     function testBuyTokensSetEthUsdRate() public {
         sendEth = 10 ether;
-        ethUSDRate = 300 ether;
-        feed.setETHUSDRate(ethUSDRate);
+        ethUsdRate = 300 ether;
+        feed.setEthUsdRate(ethUsdRate);
         user.doBuyTokens(sendEth);
-        assertEq(dpt.balanceOf(this),DPT_SUPPLY - (wdiv(wmul(ethUSDRate, sendEth), dptUSDRate)));
+        assertEq(dpt.balanceOf(this),DPT_SUPPLY - (wdiv(wmul(ethUsdRate, sendEth), dptUsdRate)));
     }
 
     function testBuyTokensSetEthUsdAndDptUsdRate() public {
         sendEth = 10 ether;
-        ethUSDRate = 300 ether;
-        dptUSDRate = 5 ether ;
-        ico.setDPTRate(dptUSDRate);
-        feed.setETHUSDRate(ethUSDRate);
+        ethUsdRate = 300 ether;
+        dptUsdRate = 5 ether ;
+        ico.setDptRate(dptUsdRate);
+        feed.setEthUsdRate(ethUsdRate);
         user.doBuyTokens(sendEth);
-        assertEq(dpt.balanceOf(this),DPT_SUPPLY - (wdiv(wmul(ethUSDRate, sendEth), dptUSDRate)));
+        assertEq(dpt.balanceOf(this),DPT_SUPPLY - (wdiv(wmul(ethUsdRate, sendEth), dptUsdRate)));
+        assert(false);
     }
 
     function testBuyTenTokensSetEthUsdAndDptUsdRateStatic() public {
-        ico.setDPTRate(5 ether);
-        feed.setETHUSDRate(20 ether);
+        ico.setDptRate(5 ether);
+        feed.setEthUsdRate(20 ether);
         user.doBuyTokens(10 ether);
         assertEq(dpt.balanceOf(user), 40 ether);
     }
 
     function testBuyTokenSetManualEthUsdRateUpdate() public {
         sendEth = 10 ether;
-        ethUSDRate = 300 ether;
+        ethUsdRate = 300 ether;
         feed.setValid(false);
-        ico.setManualUSDRate(true);
-        ico.setETHRate(ethUSDRate);
+        ico.setManualUsdRate(true);
+        ico.setEthRate(ethUsdRate);
         user.doBuyTokens(sendEth);
-        assertEq(dpt.balanceOf(this),DPT_SUPPLY - (wdiv(wmul(ethUSDRate, sendEth), dptUSDRate)));
+        assertEq(dpt.balanceOf(this),DPT_SUPPLY - (wdiv(wmul(ethUsdRate, sendEth), dptUsdRate)));
     }
 
-    function testFailBuyTokenSetManualEthUsdRateUpdateIfManuaUSDRatelIsFalse() public {
+    function testFailBuyTokenSetManualEthUsdRateUpdateIfManuaUsdRatelIsFalse() public {
         sendEth = 10 ether;
-        ethUSDRate = 300 ether;
-        ico.setETHRate(ethUSDRate);
+        ethUsdRate = 300 ether;
+        ico.setEthRate(ethUsdRate);
         user.doBuyTokens(sendEth);
-        assertEq(dpt.balanceOf(this),DPT_SUPPLY - (wdiv(wmul(ethUSDRate, sendEth), dptUSDRate)));
+        assertEq(dpt.balanceOf(this),DPT_SUPPLY - (wdiv(wmul(ethUsdRate, sendEth), dptUsdRate)));
     }
 
     function testInvalidFeedDoesNotUpdateEthUsdRate() public {
         sendEth = 134 ether;
-        uint feedEthUSDRate = 1400 ether; //should not equal to `ethUSDRate` if you want a reasonable test
-        ico.setManualUSDRate(true);
+        uint feedEthUsdRate = 1400 ether; //should not equal to `ethUsdRate` if you want a reasonable test
+        ico.setManualUsdRate(true);
         feed.setValid(false);
-        feed.setETHUSDRate(feedEthUSDRate);
+        feed.setEthUsdRate(feedEthUsdRate);
         user.doBuyTokens(sendEth);
-        assertEq(dpt.balanceOf(user), wdiv(wmul(ethUSDRate, sendEth), dptUSDRate));
+        assertEq(dpt.balanceOf(user), wdiv(wmul(ethUsdRate, sendEth), dptUsdRate));
     }
 
     function testFailInvalidFeedFailsIfManualUpdateIsFalse() public {
         sendEth = 134 ether;
-        ico.setManualUSDRate(false);
+        ico.setManualUsdRate(false);
         feed.setValid(false);
         user.doBuyTokens(sendEth);
     }
 
     function testSetFeed() public {
         sendEth = 10 ether;
-        ethUSDRate = 2000 ether;
-        TestMedianizerLike feed1 = new TestMedianizerLike(ethUSDRate, true);
+        ethUsdRate = 2000 ether;
+        TestMedianizerLike feed1 = new TestMedianizerLike(ethUsdRate, true);
         ico.setPriceFeed(feed1);
         user.doBuyTokens(sendEth);
-        assertEq(dpt.balanceOf(user), wdiv(wmul(ethUSDRate, sendEth), dptUSDRate));
+        assertEq(dpt.balanceOf(user), wdiv(wmul(ethUsdRate, sendEth), dptUsdRate));
     }
 
     function testFailSetZeroAddressFeed() public {

--- a/src/DPTICO.t.sol
+++ b/src/DPTICO.t.sol
@@ -145,7 +145,6 @@ contract DPTICOTest is DSTest, DSMath, DPTICOEvents {
         feed.setEthUsdRate(ethUsdRate);
         user.doBuyTokens(sendEth);
         assertEq(dpt.balanceOf(this),DPT_SUPPLY - (wdiv(wmul(ethUsdRate, sendEth), dptUsdRate)));
-        assert(false);
     }
 
     function testBuyTenTokensSetEthUsdAndDptUsdRateStatic() public {


### PR DESCRIPTION
You only have to set the DPT/USD price once, and no more `setRate()` is necessary.

In this version the contract automatically loads the current ETH/USD price from MakerDAO price feed which has a code: [Medianizer code](https://github.com/makerdao/medianizer.) The good thing in that price feed is that MakerDAO's core service depends on the price feed, and thus they must make sure it is operational at all times. It is also possible to assign a new feed.

Now every time the user sends money to the DPTICO contract, the current ETH/USD price is read from Maker's contract, and used to calculate DPT amount. 

You can set new price feed address`setPriceFeed()`, and can also set ETH/USD rate if price feed fails to provide valid price data `setEthRate()`. You can set the DPT/USD rate with `setDptRate()`. 

In case price feed does not provide valid price data the default behavior is to use the last valid data. And you can update the ETH/USD rate manually using `setEthRate()` (as you do now with `setRate()`). If you set `setManualUsdRate(false)` then if users send Ether to DPTICO contract, then it will be reverted as long as no valid price data is available.

Events have been added to make it possible to track all events from any software connected to Ethereum.

There is also a deploy script is written to make contract deployment a snap.
TODO: Connect to current DPT - Create a version where we connect DPTICO with current DPT smartcontract, and thus we can use the automatic price read function. 
TODO: Set timelimit, and amount limit to ICO. If not enough ETH or USD will be collected until a preset time, then all the Ether will be sent back to the users. (This is the fair way to do the ICO).
